### PR TITLE
Fixed compiler warning for filter.c

### DIFF
--- a/src/fir/filter.c
+++ b/src/fir/filter.c
@@ -185,7 +185,7 @@
  *         0 -> invalid choice!
  * Last update: 11.May.2007
  */
-int valid_filter (char *F_type, char *modified_IRS) {
+int valid_filter (char *F_type, char modified_IRS) {
   int valid = 0;
 
   if (strncmp (F_type, "irs", 3) == 0 || strncmp (F_type, "IRS", 3) == 0


### PR DESCRIPTION
`modified_IRS`  parameter was incorrectly declared as a pointer in `valid_filter()` declaration.