### PR TITLE
fix truncate tests (#58)

### DIFF
--- a/src/truncate/CMakeLists.txt
+++ b/src/truncate/CMakeLists.txt
@@ -8,14 +8,13 @@ add_test(truncate1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/truncate -ib 8000 -b 6000 t
 add_test(truncate1-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/bin_bst_6k.ref test_data/bin_bst_6k.proc)
 
 add_test(truncate2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/truncate -ib 8000 -b 6000 test_data/byte_bst.test test_data/byte_bst_6k.proc)
-add_test(truncate2-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/byte_bst.test test_data/byte_bst_6k.proc)
+add_test(truncate2-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/byte_bst_6k.ref test_data/byte_bst_6k.proc)
 
 add_test(truncate3 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/truncate -b 6000 test_data/byte_sync_bst.test test_data/byte_sync_bst_6k.proc)
-add_test(truncate3-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf test_data/byte_sync_bst.test test_data/byte_sync_bst_6k.proc)
+add_test(truncate3-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf test_data/byte_sync_bst_6k.ref test_data/byte_sync_bst_6k.proc)
 
 add_test(truncate4 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/truncate -ib 8000 -b 6000 test_data/g192_bst.test test_data/g192_bst_6k.proc)
-add_test(truncate4-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/g192_bst.test test_data/g192_bst_6k.proc)
+add_test(truncate4-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/g192_bst_6k.ref test_data/g192_bst_6k.proc)
 
 add_test(truncate5 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/truncate -b 6000 test_data/g192_sync_bst.test test_data/g192_sync_bst_6k.proc)
-add_test(truncate5-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/g192_sync_bst.test test_data/g192_sync_bst_6k.proc)
-
+add_test(truncate5-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q test_data/g192_sync_bst_6k.ref test_data/g192_sync_bst_6k.proc)

--- a/src/truncate/truncate.c
+++ b/src/truncate/truncate.c
@@ -132,6 +132,7 @@ static int conv_inpBst (char type, int n, char sync_header, FILE * pfile, FILE *
     }
     break;
   }
+  free(patt);
 
   return 0;
 }
@@ -279,7 +280,7 @@ int main (int argc, char *argv[]) {
 
     /* close files */
     fclose (pfilin);
-#ifdef TMPFILE_FIX
+#ifndef TMPFILE_FIX
     fclose (pfiltmp);
 #endif
 
@@ -371,9 +372,7 @@ int main (int argc, char *argv[]) {
   /* FINALIZATIONS */
 
   /* close the opened files */
-#ifndef TMPFILE_FIX
   fclose (pfilin);
-#endif
   fclose (pfilout);
   if (pfilrate != NULL)
     fclose (pfilrate);

--- a/src/truncate/truncate.c
+++ b/src/truncate/truncate.c
@@ -43,8 +43,6 @@
 
 */
 
-#define TMPFILE_FIX             /* temporary; only to checkout v1.3 */
-
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -145,9 +143,6 @@ int main (int argc, char *argv[]) {
   FILE *pfiltmp;                /* temporary bitstream file */
   char filin[MAX_STRLEN];       /* name of the input bitstream file */
   char filout[MAX_STRLEN];      /* name of the output bitstream file */
-#ifndef TMPFILE_FIX
-  char filtmp[9] = "~bst.tmp";  /* name of the temporary bistream file */
-#endif
 
   /* buffers */
   short bstIn[MAX_BST_LENGTH];  /* input frame */
@@ -155,7 +150,6 @@ int main (int argc, char *argv[]) {
 
   /* Algorithm variables */
   char type;                    /* type of the input bitstream */
-  char conv = 0;
   char type_ER;
   char sync_header = 0;
   short n;
@@ -259,41 +253,23 @@ int main (int argc, char *argv[]) {
     }
 
     /* Open temporary bitstream file */
-#ifdef TMPFILE_FIX
     if ((pfiltmp = tmpfile ()) == NULL) {
       fprintf (stderr, "Error creating temporary bitstream file.\n");
       exit (-1);
     }
-#else
-    if ((pfiltmp = fopen (filtmp, "wb")) == NULL) {
-      fprintf (stderr, "Error creating temporary bitstream file %s\n", filtmp);
-      exit (-1);
-    }
-#endif
 
     /* set block length for conversion */
     n = (sync_header) ? N : (short) (framelength * inprate);
 
     /* conversion */
     conv_inpBst (type, n, sync_header, pfilin, pfiltmp);
-    conv = 1;
 
     /* close files */
     fclose (pfilin);
-#ifndef TMPFILE_FIX
-    fclose (pfiltmp);
-#endif
 
     /* open converted bitstream as input bitstream file */
-#ifdef TMPFILE_FIX
+    rewind (pfiltmp);
     pfilin = pfiltmp;
-    rewind (pfilin);
-#else
-    if ((pfilin = fopen (filtmp, "rb")) == NULL) {
-      fprintf (stderr, "Error opening converted bitstream file %s\n", filtmp);
-      exit (-1);
-    }
-#endif
   }
 
   /* check output bistream file */
@@ -376,10 +352,6 @@ int main (int argc, char *argv[]) {
   fclose (pfilout);
   if (pfilrate != NULL)
     fclose (pfilrate);
-#ifndef TMPFILE_FIX
-  if (conv)                     /* remove temporary bitstream file */
-    remove (filtmp);
-#endif
-
+  
   return (0);
 }


### PR DESCRIPTION
- truncate function was crashing caused by an too early fclose() and hence produced no output data
- verifies used wrong reference files

fixes #58