### PR TITLE
Moving sub-add to utl (addressing #97)

### DIFF
--- a/manual/LaTeX/unsup.tex
+++ b/manual/LaTeX/unsup.tex
@@ -96,7 +96,7 @@ made which can be shared and incorporated in the STL.
         AC/DC/phase/ frequency/sampling frequency values. For
         VMS/Unix/MSDOS.
 
-\item[sub-add.c:]
+\item[signal-diff.c:]
         subtract/add files (depending on the compilation, see
         makefiles). For VMS/Unix/MSDOS.
 

--- a/src/unsup/CMakeLists.txt
+++ b/src/unsup/CMakeLists.txt
@@ -1,9 +1,5 @@
 include_directories(../utl)
 
-add_executable(add sub-add.c)
-target_compile_definitions(add PRIVATE ADD_FILES)
-add_executable(sub sub-add.c)
-
 add_executable(asc2bin asc2bin.c)
 target_link_libraries(asc2bin ${M_LIBRARY})
 

--- a/src/utl/CMakeLists.txt
+++ b/src/utl/CMakeLists.txt
@@ -4,6 +4,8 @@ target_link_libraries(spdemo ${M_LIBRARY})
 add_executable(scaldemo scaldemo.c ugst-utl.c)
 target_link_libraries(scaldemo ${M_LIBRARY})
 
+add_executable(signal-diff signal-diff.c)
+
 #TODO Input file is not _yet_ there.
 add_test(scaldemo1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/scaldemo -q -trunc ../is54/test_data/voice.src test_data/voice.tru 256 1 0 0.5941352)
 add_test(scaldemo1-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cf -q ../sv56/test_data/voice.ltl test_data/voice.tru)

--- a/src/utl/signal-diff.c
+++ b/src/utl/signal-diff.c
@@ -88,7 +88,7 @@ char mrs[15] = "mrs=512";
 void display_usage (char *argv[]) {
   printf ("Usage: %s [-options] file1 file2 %s\n", argv[0], "[BlkSiz [1stBlock [NoOfBlocks [output] ]]]");
   printf ("\nOptions:\n");
-  printf ("  -delay n	delay the 1st file by n samples and then compare.\n");
+  printf ("  -delay n  delay the 1st file by n samples and then compare.\n");
   printf ("            a negative n causes the 2nd file to be delayed.\n");
   printf ("  -equiv n  consider differences of upto +- to be equivalent files\n");
   printf ("            and report as such.\n");


### PR DESCRIPTION
- Moved sub-add.c from unsup to utl folder and renamed to signal-diff.c
- Removed reference to sub-add.c from ./unsup/CMakeLists.txt
- Added signal-diff.c in ./utl/CMakeLists.txt
- Corrected spacing in signal-diff help