### PR TITLE
bugfixes for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ src/is54/test_data/voice-pf.rek
 src/is54/test_data/voice.bbs
 src/is54/test_data/voice.bec
 src/is54/test_data/voice.hbs
+!src/is54/test_data/voice.log
 src/is54/test_data/voice.rek
 src/sv56/test_data/voice.prc
 src/sv56/test_data/voice.rms
@@ -73,8 +74,8 @@ CTestTestfile.cmake
 *.blg
 *.fdb_latexmk
 *.fls
-*.out
-*.pdf
+manual/Latex/*.out
+manual/LaTeX/*.pdf
 *.synctex.gz
 *.toc
 


### PR DESCRIPTION
- ignoring all .pdf files was not a good idea since there are a lot of graphics and Archive pdfs
- ignoring all .out files is not good either since a lot of test data has this ending
- Therefore just exclude .out and .pdf files in manual directory