### PR TITLE
Fixing manual (again): added missing reference

### DIFF
--- a/manual/LaTeX/Makefile
+++ b/manual/LaTeX/Makefile
@@ -1,11 +1,13 @@
-LATEX = latex
 BIBTEX = bibtex
 PDFLATEX = pdflatex
 
-PARTS = STLmanual.tex intro.tex g711.tex g711iplc.tex g726.tex g727.tex g728.tex g722.tex rpe.tex rate.tex eid.tex mnru.tex sv56.tex reverb.tex truncate.tex freqresp.tex stereoop.tex basop.tex utl.tex bibliography.bib
+PARTS = STLmanual.tex intro.tex g711.tex g711iplc.tex g726.tex g727.tex g728.tex g722.tex rpe.tex rate.tex eid.tex mnru.tex sv56.tex reverb.tex truncate.tex freqresp.tex stereoop.tex basop.tex utl.tex
 
-STLmanual.pdf : $(PARTS)
-	$(PDFLATEX) $<; $(BIBTEX) $*; $(PDFLATEX) $<; $(PDFLATEX) $<
+STLmanual.pdf : $(PARTS) bibliography.bib
+	$(PDFLATEX) $(PARTS)
+	$(BIBTEX) STLmanual
+	$(PDFLATEX) $(PARTS)
+	$(PDFLATEX) $(PARTS)
 
 clean:
 	\rm -f STLmanual.pdf *.aux *.log *.out *.toc

--- a/manual/LaTeX/bibliography.bib
+++ b/manual/LaTeX/bibliography.bib
@@ -353,6 +353,16 @@ month = "January",
 year = 2003
 )
 
+@techreport(AC-1004-Q10-15,
+title= "{Software tool to compute dynamic RAM}",
+author="{France Telecom Orange}",
+type= "{Rapporteur Group meeting Contribution}",
+number= "AC-1004-Q10-15",
+institution= "ITU-T Study Group 16 Q10/16",
+year= "2009-2012",
+url = "\url{https://www.itu.int/ifa/t/2009/sg16/exchange/wp3/q10/1004Geneva/AC-1004-Q10-15-dram.doc}"
+)
+
 @book(Recipes,
 title= "{Numerical Recipes in C: The Art of Scientific Computing }",
 author= "W. H. Press and B. P. Flannery and S. A. Teukolky and W. T. Vetterling",


### PR DESCRIPTION
Adds missing reference AC-1004-Q10-15 (fixes #110).

In addition, the Makefile was still broken and is now working properly.