### PR TITLE
utl/spdemo: set default value for string-based parameter.

### DIFF
--- a/src/utl/ugstdemo.h
+++ b/src/utl/ugstdemo.h
@@ -183,7 +183,7 @@
      fprintf (stderr,"%s%c\n",msg,C);}
 
 #define FIND_PAR_S(p,msg,i,dft) \
-   { strcpy(i,(argc>p)?argv[p]:dft);\
+   { memmove(i,(argc>p)?argv[p]:dft, strlen((argc>p)?argv[p]:dft));\
      fprintf (stderr,"%s%s\n",msg,i); }
 
 #define FIND_PAR_L(p,msg,i,j) \


### PR DESCRIPTION
__ATTENTION:__ This solution is just a guess and needs testing (especially on MacOS).

This might be a fix for #46.

_Potential explanation:_
I believe the issue results from using `strcpy` on `src` == `dst`.
This is not allowed as `src` and `dst` should not overlap.