### PR TITLE
Continous integration goes MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language:
 
 compiler:
     - clang
+    - gcc
 
 script:
     - cmake .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+    - linux
+    - osx
+
 language:
     - c
     - cpp 


### PR DESCRIPTION
Enables for testing for Linux and MacOS for GCC and Clang.
With this Clang on MacOS fails for STL2009 version of spdemo (#46) - as expected.