### PR TITLE
3GPP - Fixing IF macro definition

### DIFF
--- a/src/basop/control.h
+++ b/src/basop/control.h
@@ -150,10 +150,10 @@ static __inline void incrWhile (void) {
  *
  *****************************************************************************/
 #ifndef WMOPS
-#define IF (a) if (a)
+#define IF(a) if (a)
 
 #else /* ifndef WMOPS */
-#define IF (a) if (incrIf (), a)
+#define IF(a) if (incrIf (), a)
 
 static __inline void incrIf (void) {
    /* Technical note :


### PR DESCRIPTION
This fixes the IF macro definition. Spaces were inserted in the declaration and should be removed.