### PR TITLE
TravisCI: compiles the doc/manual/STLmanual.tex via `latexmk`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,28 @@ os:
 
 language:
     - c
-    - cpp 
+    - cpp
 
 compiler:
     - clang
     - gcc
+
+addons:
+    apt:
+        packages:
+            - texlive-latex-extra
+            - texlive-fonts-recommended
+            - latexmk
+ 
+jobs:
+    include:
+    - stage:  manual
+      script: cd doc/manual && latexmk -pdf -halt-on-error STLmanual.tex < /dev/null
+      if: os = linux
+
+stages:
+    - manual
+    - test
 
 script:
     - cmake .


### PR DESCRIPTION
In this way, changes in the manual will also be "tested".
Fixes #99.