### PR TITLE
[Manual] Updating weights of existing basic operators

### DIFF
--- a/manual/LaTeX/basop.tex
+++ b/manual/LaTeX/basop.tex
@@ -2,7 +2,7 @@
 % ..... THIS IS chapter{BASOP: ITU-T Basic Operators } .....
 % ... Revision:
 % Nov.2000 - SG16 Plenary
-% Apr.2005 - STL2005 revision -- Cyril Guillaum� & St�phane Ragot - stephane.ragot@francetelecom.com
+% Apr.2005 - STL2005 revision -- Cyril Guillaumé & Stéphane Ragot - stephane.ragot@francetelecom.com
 %                                Karim Djafarian - k-djafarian@ti.com
 % Nov.2008 - STL2009 revision -- Yusuke Hiwasaki, Noboru Harada, NTT
 %                             - Balazs Kovesi, Claude Lamblin, France Telecom

--- a/manual/LaTeX/basop.tex
+++ b/manual/LaTeX/basop.tex
@@ -2,7 +2,7 @@
 % ..... THIS IS chapter{BASOP: ITU-T Basic Operators } .....
 % ... Revision:
 % Nov.2000 - SG16 Plenary
-% Apr.2005 - STL2005 revision -- Cyril Guillaumé & Stéphane Ragot - stephane.ragot@francetelecom.com
+% Apr.2005 - STL2005 revision -- Cyril Guillaumï¿½ & Stï¿½phane Ragot - stephane.ragot@francetelecom.com
 %                                Karim Djafarian - k-djafarian@ti.com
 % Nov.2008 - STL2009 revision -- Yusuke Hiwasaki, Noboru Harada, NTT
 %                             - Balazs Kovesi, Claude Lamblin, France Telecom
@@ -18,29 +18,21 @@
 \section{Overview of basic operator libraries}
 %----------------------------------------------------------------------
 
-Since the standardization of G.729 and G.723.1\footnote{For older
-  standards (G.711, G.726, G722, G.727, G.728), their C-codes are
-  included in the software tools library.}, ANSI-C source codes
-constitute integral parts of the ITU-T speech and audio coding
-Recommendations and their specification relies on bit-exact
-fixed-point C code using library of basic operators that simulates
-DSP operations. The fixed-point descriptions of G.723.1 and G.729 are based on
-16- and 32-bit arithmetic operations defined by ETSI in 1993 for the
-standardisation of the half-rate GSM speech codec. These operations
-are also used to define the GSM enhanced full-rate (EFR) and adaptive
-multi-rate (AMR) speech codecs \cite{G.191}.
+Since the standardization of G.729 and G.723.1
+\footnote{For older standards (G.711, G.726, G722, G.727, G.728), their C-codes are included in the software tools library.},
+ANSI-C source codes constitute integral parts of the ITU-T speech and audio coding Recommendations and their specification relies on bit-exact fixed-point C code using library of basic operators that simulates DSP operations.
+The fixed-point descriptions of G.723.1 and G.729 are based on 16- and 32-bit arithmetic operations defined by ETSI in 1993 for the standardisation of the half-rate GSM speech codec.
+These operations are also used to define the GSM enhanced full-rate (EFR) and adaptive multi-rate (AMR) speech codecs \cite{G.191}.
 
-In STL2005, the version 2.0 of the ITU-T Basic Operators bears the following additional features compared to the version 1.x:
+In STL2018, the version 2.0 of the ITU-T Basic Operators bears the following additional features compared to the version 1.x:
 \begin{enumerate}
 \item New 16-bit and 32-bit operators;
 \item New 40-bit operators;
-\item New control flow operators; 
+\item New control flow operators;
 \item Revised complexity weight of version 1.x basic operators in order to reflect the evolution of processor capabilities.
 \end{enumerate}
 
-In STL2009, that is version 2.3, in addition to some minor fixes in
-the ITU-T Basic Operators and guidelines of data move counters , the
-following new additional tools were added:
+In STL2009, that is version 2.3, in addition to some minor fixes in the ITU-T Basic Operators and guidelines of data move counters, the following new additional tools were added:
 \begin{itemize}
 \item Program ROM estimation tool for fixed-point C Code;
 \item Complexity evaluation tool for floating-point C Code.
@@ -50,40 +42,40 @@ following new additional tools were added:
 In STL2014 (version 2.4) release, the following modifications were made:
 \begin{itemize}
 \item Addition of dynamic RAM counting tool
-\item Revisions on Program ROM estimation tool and complexity
-  evaluation tool for floating-point C code.
+\item Revisions on Program ROM estimation tool and complexity evaluation tool for floating-point C code.
 \end{itemize}
-It should also be noted that {\tt L\_sub\_c} operator is reported to
-have a carry problem and volunteers are seeked to correct the
-problem. Use of {\tt L\_sub\_c} and {\tt L\_msuNs} are NOT recommended.
+It should also be noted that {\tt L\_sub\_c} operator is reported to have a carry problem and volunteers are seeked to correct the problem.
+Use of {\tt L\_sub\_c} and {\tt L\_msuNs} are NOT recommended.
+}
+
+\textcolor{purple}{
+In STL2018, new operators were introduced to account for modern DSP architectures:
+\begin{enumerate}
+    \item Enhanced 32-bit operators;
+    \item New unsigned 32-bit operators;
+    \item New 64-bit operators;
+    \item New complex operators;
+    \item New control flow operators;
+    \item Revised complexity weights in order to reflect the evolution of processor capabilities.
+\end{enumerate}
 }
 
 %----------------------------------------------------------------------
-\section{Description of the 16-bit and 32-bit basic operators and 
-associated weights}
+\section{Description of the 16-bit and 32-bit basic operators and associated weights}
 %----------------------------------------------------------------------
 
-This section describes the different 16-bit and 32-bit basic operators
-available in the STL, and are organized by complexity
-(``weights''). The complexity values to be considered (since the
-publication of the STL2005) are the ones related to the version 2.0
-and subsequent versions of the module. When the basic operator had a
-different complexity value in the previous version of the library
-(version 1.x), the previous complexity value is indicated for
-information.  When the basic operator did not exist in the previous
-version of the library (version 1.x), it is highlighted as follows:
-\newop20 . In STL2009, {\tt round()} operator was renamed as {\tt
-  round\_fx()} and {\tt saturate()}, function was made unaccessible
-from applications, because it was an internal procedure.
+This section describes the different 16-bit and 32-bit basic operators available in the STL, and are organized by complexity (``weights'').
+The complexity values to be considered (since the publication of the STL2005) are the ones related to the version 2.0 and subsequent versions of the module.
+When the basic operator had a different complexity value in the previous version of the library(version 1.x), the previous complexity value is indicated for information.
+When the basic operator did not exist in the previous version of the library (version 1.x), it is highlighted as follows:
+\newop20 . In STL2009, {\tt round()} operator was renamed as {\tt round\_fx()} and {\tt saturate()}, function was made unaccessible from applications, because it was an internal procedure.
 
 \subsection{Variable definitions}
 
-The variables used in the operators are signed integers in 2's
-complements representation, defined by:
+The variables used in the operators are signed integers in 2's complements representation, defined by:
 
 {\tt v1}, {\tt v2}: 16-bit variables\\
 {\tt L\_v1}, {\tt L\_v2}, {\tt L\_v3}: 32-bit variables
-
 
 
 %-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.
@@ -93,37 +85,31 @@ complements representation, defined by:
 %........................................................
 \NewOperator{add(v1, v2)}
 
-Performs the addition ({\tt v1}+{\tt v2}) with overflow control and
-saturation; the 16-bit result is set at {\tt +32767} when overflow
-occurs or at {\tt -32768} when underflow occurs.
+Performs the addition ({\tt v1}+{\tt v2}) with overflow control and saturation; the 16-bit result is set at {\tt +32767} when overflow occurs or at {\tt -32768} when underflow occurs.
 
 %........................................................
 \NewOperator{sub(v1, v2)}
 
-Performs the subtraction ({\tt v1}-{\tt v2}) with overflow control and
-saturation; the 16-bit result is set at {\tt +32767} when overflow
-occurs or at {\tt -32768} when underflow occurs.
+Performs the subtraction ({\tt v1}-{\tt v2}) with overflow control and saturation; the 16-bit result is set at {\tt +32767} when overflow occurs or at {\tt -32768} when underflow occurs.
 
 %........................................................
 \NewOperator{abs\_s(v1)}
 
-Absolute value of v1. If {\tt v1} is {\tt -32768}, returns {\tt 32767}.
+Absolute value of v1.
+If {\tt v1} is {\tt -32768}, returns {\tt 32767}.
 
 %........................................................
 \NewOperator{shl(v1, v2)}
 
-Arithmetically shift the 16-bit input {\tt v1} left {\tt v2}
-positions. Zero fill the {\tt v2} LSB of the result. If {\tt v2} is
-negative, arithmetically shift {\tt v1} right by {\tt -v2} with sign
-extension. Saturate the result in case of underflows or overflows.
+Arithmetically shift the 16-bit input {\tt v1} left {\tt v2} positions.
+Zero fill the {\tt v2} LSB of the result. If {\tt v2} is negative, arithmetically shift {\tt v1} right by {\tt -v2} with sign extension.
+Saturate the result in case of underflows or overflows.
 
 %........................................................
 \NewOperator{shr(v1, v2)}
 
-Arithmetically shift the 16-bit input {\tt v1} right {\tt v2}
-positions with sign extension. If v2 is negative, arithemtically shift
-{\tt v1} left by {\tt -v2} and zero fill the {\tt -v2} LSB of the
-result:
+Arithmetically shift the 16-bit input {\tt v1} right {\tt v2} positions with sign extension.
+If v2 is negative, arithemtically shift {\tt v1} left by {\tt -v2} and zero fill the {\tt -v2} LSB of the result:
 
 \rulex{2mm}{\tt shr(v1, v2) = shl(v1, -v2)}
 
@@ -132,22 +118,19 @@ Saturate the result in case of underflows or overflows.
 %........................................................
 \NewOperator{negate(v1)}
 
-Negate {\tt v1} with saturation, saturate in the case when input
-is {\tt -32768}:
+Negate {\tt v1} with saturation, saturate in the case when input is {\tt -32768}:
 
 \rulex{2mm}{\tt negate(v1) = sub(0, v1)}
 
 %........................................................
 \NewOperator{s\_max(v1, v2)} \newop20
 
-Compares two 16-bit variables {\tt v1} and {\tt v2} and returns
-the maximum value. 
+Compares two 16-bit variables {\tt v1} and {\tt v2} and returns the maximum value.
 
 %........................................................
 \NewOperator{s\_min(v1, v2)} \newop20
 
-Compares two 16-bit variables {\tt v1} and {\tt v2} and returns
-the minimum value. 
+Compares two 16-bit variables {\tt v1} and {\tt v2} and returns the minimum value.
 
 %........................................................
 \NewOperator{norm\_s(v1)}

--- a/manual/LaTeX/basop.tex
+++ b/manual/LaTeX/basop.tex
@@ -48,7 +48,7 @@ It should also be noted that {\tt L\_sub\_c} operator is reported to have a carr
 Use of {\tt L\_sub\_c} and {\tt L\_msuNs} are NOT recommended.
 }
 
-\textcolor{purple}{
+\textcolor{red}{
 In STL2018, new operators were introduced to account for modern DSP architectures:
 \begin{enumerate}
     \item Enhanced 32-bit operators;
@@ -565,7 +565,7 @@ of underflows or overflows.
 \rulex{2mm} else if (v2 $\leq$ 0) \\
    \rulex{4mm} then shr\_r(v1, v2) = shr(v1, v2)}
 
-\textcolor{purple} {
+\textcolor{red} {
 \textbf{Note:} \hfill \pbox{145mm}{In v2.3, the complexity weight of this operator was  3.}
 }
 
@@ -1207,59 +1207,66 @@ operators and their associated complexity.
 % Table with the control basic operators and their associated complexity.
 %-------------------------------------------------------------------------
 \begin{table}[th]
-\Caption{14cm}{\SF Control basic operators and associated
-complexity. \label{tbl:control-basicop}}
+\Caption{14cm}{\SF Control basic operators and associated complexity. \label{tbl:control-basicop}}
 \begin{center}
 \footnotesize
 \begin{tabular}{|c|l|l|}
 \hline Complexity Weight  & Basic Operator  & Description\\
-\hline \hline {0}    & \textbf{DO}\{...\} while(expression) &
-\parbox[t]{70mm}{\SF The
-macro DO must be used instead of the 'do' C statement.}\\
-\hline {3} & \textbf{FOR}(expr1; expr2; expr3) \{...\} &
-\parbox[t]{70mm}{\SF The macro FOR must be used instead of the
-'for' C statement. The complexity is \textbf{independent} of the
-number of loop iterations that are performed.} \\
-\hline {0} & \parbox[t]{60mm}{\SF \textbf{if}(expression)
-\textbf{one\_and\_only\_one\_basic\_operator (control operators
-excluded)}} & \parbox[t]{70mm}{\SF \textbf{The macro IF must not
-be used} when the 'if' structure does not have any 'else if' nor
-'else' statement and it conditions only one basic operator
-(control operators excluded)}. \\
-\hline {4} & \parbox[t]{60mm}{\SF \textbf{IF}(expression) \{...\}}
-&
-\parbox[t]{70mm}{\SF The macro IF must be used instead of the 'if'
-C statement \textbf{in every other case}: when there is an 'else'
-or 'else if' statement, or when the 'if' conditions several basic
-operators, or when the 'if' conditions a function call or when the
-'if' conditions a control operator.}\\
-\hline {4} & \parbox[t]{60mm}{\SF if(expression) \{...\} [[\\
-\textbf{ELSE} if(expression2)\{...\}]\\ \textbf{ELSE} \{...\}]} &
-\parbox[t]{70mm}{\SF The macro ELSE must be used instead of the
-'else' C
-statement.}\\
-\hline {8} & \textbf{SWITCH}(expression) \{...\} &
-\parbox[t]{70mm}{\SF The macro SWITCH must be used instead of the
-'switch' C statement.}\\
-\hline {4} & \textbf{WHILE}(expression) \{...\} &
-\parbox[t]{70mm}{\SF The macro WHILE must be used instead of the
-'while' C statement.\\
-The complexity is \textbf{proportional} to the number of loop
-iterations that are performed.}\\
-\hline {4} & \parbox[t]{60mm}{\SF while(expression) \{ \\...
-\textbf{CONTINUE}; ...\\ \}\\ or\\ for(expr1; expr2; expr3) \{
-\\...\\ \textbf{CONTINUE}; \\...\\ \}\\ } &
-\parbox[t]{70mm}{\SF The macro CONTINUE must be used instead of
-the 'continue' C statement.}\\
-\hline {4} & \parbox[t]{60mm}{\SF while(expression) \{ \\...
-\textbf{BREAK}; ...\\ \}\\ or\\ for(expr1; expr2; expr3) \{
-\\...\\ \textbf{BREAK}; \\...\\ \}\\or\\
-switch(var) \{ \\...\\ \textbf{BREAK};\\...\\\}
- } &
-\parbox[t]{70mm}{\SF The macro BREAK must be used instead of
-the 'break' C statement.}\\
-\hline {4} &  \textbf{GOTO}  & \parbox[t]{60mm}{\SF The macro GOTO
-must be used instead of the 'goto' C statement.}\\
+\hline \hline {0}    &
+    \textbf{DO}\{...\} while(expression) &
+    \parbox[t]{70mm}{\SF The macro DO must be used instead of the 'do' C statement.}\\
+\hline {3} &
+    \textbf{FOR}(expr1; expr2; expr3) \{...\} &
+    \parbox[t]{70mm}{\SF The macro FOR must be used instead of the 'for' C statement.
+    The complexity is \textbf{independent} of the number of loop iterations that are performed.} \\
+\hline {0} &
+    \parbox[t]{60mm}{\SF \textbf{if}(expression)
+    \textbf{one\_and\_only\_one\_basic\_operator (control operators excluded)}} & \parbox[t]{70mm}{\SF \textbf{The macro IF must not be used} when the 'if' structure does not have any 'else if' nor 'else' statement and it conditions only one basic operator (control operators excluded)}. \\
+\hline {3} &
+    \parbox[t]{60mm}{\SF \textbf{IF}(expression) \{...\}} &
+    \parbox[t]{70mm}{\SF The macro IF must be used instead of the 'if' C statement \textbf{in every other case}: when there is an 'else' or 'else if' statement, or when the 'if' conditions several basic operators, or when the 'if' conditions a function call or when the 'if' conditions a control operator.}\\
+\hline {4} &
+    \parbox[t]{60mm}{\SF if(expression) \{...\} [[\\
+        \textbf{ELSE} if(expression2)\{...\}]\\
+        \textbf{ELSE} \{...\}]} &
+    \parbox[t]{70mm}{\SF The macro ELSE must be used instead of the 'else' C statement.}\\
+\hline {6} &
+    \textbf{SWITCH}(expression) \{...\} &
+    \parbox[t]{70mm}{\SF The macro SWITCH must be used instead of the 'switch' C statement.}\\
+\hline {3} &
+    \textbf{WHILE}(expression) \{...\} &
+    \parbox[t]{70mm}{\SF The macro WHILE must be used instead of the 'while' C statement.\\
+        The complexity is \textbf{proportional} to the number of loop iterations that are performed.}\\
+\hline {2} &
+    \parbox[t]{60mm}{\SF while(expression) \{ \\
+        ... \textbf{CONTINUE}; ...\\ \}\\
+        or\\
+        for(expr1; expr2; expr3) \{ \\
+        ...\\
+        \textbf{CONTINUE}; \\
+        ...\\
+        \}} &
+    \parbox[t]{70mm}{\SF The macro CONTINUE must be used instead of the 'continue' C statement.}\\
+\hline {2} &
+    \parbox[t]{60mm}{\SF while(expression) \{ \\
+        ...\textbf{BREAK}; ...\\
+        \}\\
+        or\\
+        for(expr1; expr2; expr3) \{\\
+        ...\\
+        \textbf{BREAK}; \\...\\
+        \}\\
+        or\\
+        switch(var) \{ \\
+        ...\\
+        \textbf{BREAK};\\
+        ...
+        \\
+        \}} &
+    \parbox[t]{70mm}{\SF The macro BREAK must be used instead of the 'break' C statement.}\\
+\hline {2} &
+    \textbf{GOTO}  &
+    \parbox[t]{60mm}{\SF The macro GOTO must be used instead of the 'goto' C statement.}\\
  \hline
 \end{tabular}
 \end{center}

--- a/manual/LaTeX/basop.tex
+++ b/manual/LaTeX/basop.tex
@@ -510,6 +510,19 @@ are sign-extended.
 
 \textbf{Note:} \hfill \pbox{145mm}{In v1.x, the complexity weight of this operator was  2.}
 
+
+%........................................................
+\NewOperator{L\_sat(L\_v1)}
+
+The 32-bit variable L\_v1 is set to {\tt 2147483647} if an overflow
+occurred, or {\tt -2147483648} if an underflow occurred, on the
+most recent {\tt L\_add\_c()}, {\tt L\_sub\_c()}, {\tt L\_macNs()}
+or {\tt L\_msuNs()} operations. The carry and overflow values are
+binary variables which can be tested and assigned values.
+
+\textbf{Note:} \hfill \pbox{145mm}{In v2.3, the complexity weight of this operator was  4. }
+
+
 \subsection{Operators with complexity weight of 2}
 
 %........................................................
@@ -535,10 +548,7 @@ binary variables which can be tested and assigned values.
 Performs the 32-bit subtraction with carry (borrow). Generates
 carry (borrow) and overflow values. No saturation. The carry and
 overflow values are binary variables which can be tested and
-assigned values. 
-
-\subsection{Operators with complexity weight of 3}
-\subsubsection{Arithmetic operators}
+assigned values.
 
 %........................................................
 \NewOperator{shr\_r(v1, v2)}
@@ -555,18 +565,9 @@ of underflows or overflows.
 \rulex{2mm} else if (v2 $\leq$ 0) \\
    \rulex{4mm} then shr\_r(v1, v2) = shr(v1, v2)}
 
-%........................................................
-\NewOperator{shl\_r(v1, v2)}
-
-Same as {\tt shl()} but with rounding. Saturate the result in case
-of underflows or overflows:
-
-\rulex{2mm}{\tt shl\_r(v1, v2) = shr\_r(v1, -v2)}
-
-\textbf{Note:} \hfill \pbox{145mm}{In v1.x, the complexity weight of
-this operator was  2. Additionally, please note that in v1.x this
-operator was called \textbf{shift\_r(v1, v2)}; in the STL2005, both
-names can be used.}
+\textcolor{purple} {
+\textbf{Note:} \hfill \pbox{145mm}{In v2.3, the complexity weight of this operator was  3.}
+}
 
 %........................................................
 \NewOperator{L\_shr\_r(L\_v1, v2)}
@@ -583,6 +584,26 @@ in case of underflows or overflows:
 
 \rulex{2mm} if (v2 $\leq$ 0) \\
   \rulex{4mm} then L\_shr\_r(L\_v1, v2) = L\_shr(L\_v1, v2)}
+
+\textbf{Note:} \hfill \pbox{145mm}{In v2.3, the complexity weight of this operator was  3.}
+
+
+\subsection{Operators with complexity weight of 3}
+\subsubsection{Arithmetic operators}
+
+%........................................................
+\NewOperator{shl\_r(v1, v2)}
+
+Same as {\tt shl()} but with rounding. Saturate the result in case
+of underflows or overflows:
+
+\rulex{2mm}{\tt shl\_r(v1, v2) = shr\_r(v1, -v2)}
+
+\textbf{Note:} \hfill \pbox{145mm}{In v1.x, the complexity weight of
+this operator was  2. Additionally, please note that in v1.x this
+operator was called \textbf{shift\_r(v1, v2)}; in the STL2005, both
+names can be used.}
+
 
 %........................................................
 \NewOperator{L\_shl\_r(L\_v1, v2)}
@@ -637,22 +658,13 @@ copied to the bit 0 of v3 variable.
 %........................................................
 \NewOperator{L\_rotr(L\_v1, v2, * v3)} \newop20
 
-Rotates the 32-bit variable L\_v1 by 1 bit to the least
-significant bits. Bit 0 of v2 is copied to the most significant
-bit of the result before it is returned. The least significant bit
-of L\_v1 is copied to the bit 0 of v3 variable.
+Rotates the 32-bit variable L\_v1 by 1 bit to the least significant bits.
+Bit 0 of v2 is copied to the most significant bit of the result before it is returned.
+The least significant bit of L\_v1 is copied to the bit 0 of v3 variable.
 
 
 \subsection{Operators with complexity weight of 4}
 
-%........................................................
-\NewOperator{L\_sat(L\_v1)}
-
-The 32-bit variable L\_v1 is set to {\tt 2147483647} if an overflow
-occurred, or {\tt -2147483648} if an underflow occurred, on the
-most recent {\tt L\_add\_c()}, {\tt L\_sub\_c()}, {\tt L\_macNs()}
-or {\tt L\_msuNs()} operations. The carry and overflow values are
-binary variables which can be tested and assigned values.
 
 \enlargethispage*{10mm}
 
@@ -1499,10 +1511,10 @@ be replaced by: \\
 
 \subsection{Data moves}
 
-Each data move between two 16-bit variables (with
-\textbf{move16}() operator) has a complexity weight of 1 and each
-data move between two 32-bit variables (with \textbf{move32}()
-operator) has a complexity weight of 2.
+Each data move between two 16-bit or two 32-bit variables, \textbf{move16}() and \textbf{move32}() operators respectively, has a complexity weight of 1.
+
+\textbf{Note:} \hfill \pbox{145mm}{In v2.3, the complexity weight of \textbf{move32}() operator was  2. }
+
 \begin{enumerate}{}{}
 \item A 16-bit variable cannot be directly moved to a 32-bit or 40-bit variable.
 \item A 32-bit variable cannot be directly moved to a 16-bit or 40-bit variable.

--- a/manual/LaTeX/basop.tex
+++ b/manual/LaTeX/basop.tex
@@ -234,6 +234,17 @@ result, the following operation must be done:
 \subsubsection{Multiplication operators}
 
 %........................................................
+\NewOperator{i\_mult(v1, v2)}
+
+Multiply two 16-bit words {\tt v1} and {\tt v2} returning a 16-bit word with overflow control.
+
+\textbf{Note:} \hfill \pbox{145mm}{
+In v1.x, the complexity weight of this operator was 1.
+The complexity update to the weight of 3 was motivated by the fact that the primitive is performing
+something equivalent to extract\_h( L\_shl( L\_mult0( v1, v2), 16)).
+}
+
+%........................................................
 \NewOperator{L\_mult(v1, v2)}
 
 Operator {\tt L\_mult} implements the 32-bit result of the
@@ -353,6 +364,13 @@ result. Generates carry and overflow values:
 
 
 \rulex{2mm}{\tt L\_msuNs(L\_v3, v1, v2) = L\_sub\_c(L\_v3, L\_mult(v1, v2))}
+
+%........................................................
+\NewOperator{L\_mls(L\_v1, v2)}
+
+Performs a multiplication of a 32-bit variable {\tt L\_v1} by a 16-bit variable {\tt v2}, returning a 32-bit value.
+
+\textbf{Note:} \hfill \pbox{145mm}{In v1.x, the complexity weight of this operator was  6.}
 
 %........................................................
 \NewOperator{msu\_r(L\_v3, v1, v2)}
@@ -553,8 +571,7 @@ assigned values.
 %........................................................
 \NewOperator{shr\_r(v1, v2)}
 
-Same as {\tt shr()} but with rounding. Saturate the result in case
-of underflows or overflows.
+Same as {\tt shr()} but with rounding. Saturate the result in case of underflows or overflows.
 
 {\tt
 \rulex{2mm} if (v2$>$0) then\\
@@ -573,8 +590,7 @@ of underflows or overflows.
 \NewOperator{L\_shr\_r(L\_v1, v2)}
 
 
-Same as {\tt L\_shr(v1,v2)} but with rounding. Saturate the result
-in case of underflows or overflows:
+Same as {\tt L\_shr(v1,v2)} but with rounding. Saturate the result in case of underflows or overflows:
 
 {\tt
 \rulex{2mm} if (v2 $>$ 0) then\\
@@ -587,7 +603,7 @@ in case of underflows or overflows:
 
 \textbf{Note:} \hfill \pbox{145mm}{In v2.3, the complexity weight of this operator was  3.}
 
-
+%________________________________________________________
 \subsection{Operators with complexity weight of 3}
 \subsubsection{Arithmetic operators}
 
@@ -616,17 +632,7 @@ result in case of underflows or overflows.
 In v1.x, this operator is called \textbf{L\_shift\_r(L\_v1, v2}) ;
 both names can be used.
 
-%........................................................
-\NewOperator{i\_mult(v1, v2)}
-
-Multiply two 16-bit words {\tt v1} and {\tt v2} returning a 16-bit
-word with overflow control.
-
-\textbf{Note:} \hfill \pbox{145mm}{In v1.x, the complexity weight of 
-this operator was  1. The complexity update to the 
-weight of 3 was motivated by the fact that the primitive is performing 
-something equivalent to extract\_h( L\_shl( L\_mult0( v1, v2), 16)).}
-
+%________________________________________________________
 \subsubsection{Logical Operators}
 
 %........................................................
@@ -669,14 +675,6 @@ The least significant bit of L\_v1 is copied to the bit 0 of v3 variable.
 \enlargethispage*{10mm}
 
 \subsection{Operators with complexity weight of 5}
-
-%........................................................
-\NewOperator{L\_mls(L\_v1, v2)}
-
-Performs a multiplication of a 32-bit variable {\tt L\_v1} by a 16-bit
-variable {\tt v2}, returning a 32-bit value.
-
-\textbf{Note:} \hfill \pbox{145mm}{In v1.x, the complexity weight of this operator was  6.}
 
 %-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.
 \subsection{Operators with complexity weight of 18}
@@ -821,6 +819,10 @@ complements representation, defined by:
 %-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.
 \subsection{Operators with complexity weight of 1}
 \subsubsection{Arithmetic operators (multiplication excluded)}
+
+\NewOperator{L40\_set(L40\_v1)}
+
+Assigns a 40-bit constant to the returned 40-bit variable.
 
 %........................................................
 \NewOperator{L40\_add(L40\_v1, L40\_v2)}
@@ -1014,64 +1016,48 @@ end-result 16 LSBits are cleared to 0.
 
 \subsection{Operators with complexity weight of 2}
 
-%........................................................
+
 \NewOperator{mac\_r40(L40\_v1, v2, v3)}
 
 Equivalent to: \\
 {\tt round40( L40\_mac( L40\_v1, v2, v3)) }
 
-%........................................................
 \NewOperator{msu\_r40(L40\_v1, v2, v3) }
 
 Equivalent to: \\
 {\tt round40( L40\_msu( L40\_v1, v2, v3)) }
 
-%........................................................
+\NewOperator{L40\_shr\_r(L40\_v1, v2)}
+
+Arithmetically shifts the 40-bit variable L40\_v1 by v2 positions to the least significant bits and rounds the result.
+It is equivalent to {\tt L40\_shr( L40\_v1, v2)} except that if v2 is positive and the last shifted out bit is 1, then the shifted result is increment by 1\textbf{without} 40-bit saturation control.
+It will exit execution if it detects a 40-bit overflow.
+
+\NewOperator{L40\_shl\_r(L40\_v1, v2)}
+
+Arithmetically shifts the 40-bit variable L40\_v1 by v2 positions to the most significant bits and rounds the result.
+It is equivalent to {\tt L40\_shl( L40\_var1, v2)} except if v2 is negative.
+In this case, it does the same as {\tt L40\_shr\_r( L40\_v1, (-v2))}.
+
 \NewOperator{Mpy\_32\_16\_ss(L\_v1, v2, *L\_v3\_h, *v3\_l)}
 
-\textbf{Multiplies the 2 signed values} L\_v1 (32-bit) and v2 (16-bit)
-with saturation control on 48-bit. The operation is performed in
-\textbf{fractional mode}: \\ 
-When L\_v1 is in 1Q31 format, and v2 is in 1Q15 format, the result is
-produced in 1Q47 format: L\_v3\_h bears the 32 most significant bits
-while v3\_l bears the 16 least significant bits.
+\textbf{Multiplies the 2 signed values} L\_v1 (32-bit) and v2 (16-bit) with saturation control on 48-bit.
+The operation is performed in \textbf{fractional mode}: \\
+When L\_v1 is in 1Q31 format, and v2 is in 1Q15 format, the result is produced in 1Q47 format: L\_v3\_h bears the 32 most significant bits while v3\_l bears the 16 least significant bits.
+
+\NewOperator{Mpy\_32\_32\_ss(L\_v1, L\_v2, *L\_v3\_h, *L\_v3\_l)}
+
+Multiplies the two signed 32-bit values L\_v1 and L\_v2 with saturation control on 64-bit.
+The operation is performed in \textbf{fractional mode}: when L\_v1 and L\_v2 are in 1Q31 format, the result is produced in 1Q63 format; L\_v3\_h bears the 32 most significant bits while L\_v3\_l bears the 32 least significant bits.
 
 \subsection{Operators with complexity weight of 3}
 
 %........................................................
-\NewOperator{L40\_shr\_r(L40\_v1, v2)}
-
-Arithmetically shifts the 40-bit variable L40\_v1 by v2 positions to
-the least significant bits and rounds the result. It is equivalent to
-{\tt L40\_shr( L40\_v1, v2)} except that if v2 is positive and the last
-shifted out bit is 1, then the shifted result is increment by 1
-\textbf{without} 40-bit saturation control. It will exit execution if
-it detects a 40-bit overflow.
-
-%........................................................
-\newpage
-\NewOperator{L40\_shl\_r(L40\_v1, v2)}
-
-Arithmetically shifts the 40-bit variable L40\_v1 by v2 positions
-to the most significant bits and rounds the result. It is
-equivalent to {\tt L40\_shl( L40\_var1, v2)} except if v2 is negative.
-In this case, it does the same as {\tt L40\_shr\_r( L40\_v1, (-v2))}.
-
-%........................................................
-\NewOperator{L40\_set(L40\_v1)}
-
-Assigns a 40-bit constant to the returned 40-bit variable.
 
 \subsection{Operators with complexity weight of 4}
 
 %........................................................
-\NewOperator{Mpy\_32\_32\_ss(L\_v1, L\_v2, *L\_v3\_h, *L\_v3\_l)}
 
-Multiplies the two signed 32-bit values L\_v1 and L\_v2 with saturation
-control on 64-bit. The operation is performed in \textbf{fractional
-mode}: when L\_v1 and L\_v2 are in 1Q31 format, the result is produced
-in 1Q63 format; L\_v3\_h bears the 32 most significant bits while
-L\_v3\_l bears the 32 least significant bits.
 
 \subsection{Coding Guidelines}
 


### PR DESCRIPTION
- Added short description for the new basic operators
- Moved basic operators to the section corresponding to their new weight.
- Adopting the "one line per sentence" style for sections that were changed.