### PR TITLE
TravisCI: enabled windows and moved from Ubuntu Trusty to Xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 os:
     - linux
     - osx
+    - windows
+
+dist: xenial
 
 language:
     - c


### PR DESCRIPTION
TravisCI made use of Trusty unsupported, as it had only support until end of 2017.
While checking their manual, I observed that support for Windows is available.

The CMake configuration works on Windows using MSVC. 

However, there quite some tests failing (especially baseops) and huge amounts of warnings...
