### PR TITLE
Gen patt fix sta name writing, fixes #161

### DIFF
--- a/src/eid/gen-patt.c
+++ b/src/eid/gen-patt.c
@@ -550,9 +550,6 @@ int main (int argc, char *argv[]) {
       }
   }
 
-  /* initialize state_file with 0, to make sure the string is terminated with \0, which FIND_PAR_S () doesn't add */
-  memset(state_file, 0, sizeof(state_file));
-
   /* Get command line parameters */
   GET_PAR_S (1, "_Output bit stream file ...........................: ", data_file_name);
   FIND_PAR_C (2, "_Processing mode (Random,Frame,Burst) [RFB] .......: ", mode, mode);

--- a/src/eid/gen-patt.c
+++ b/src/eid/gen-patt.c
@@ -550,6 +550,9 @@ int main (int argc, char *argv[]) {
       }
   }
 
+  /* initialize state_file with 0, to make sure the string is terminated with \0, which FIND_PAR_S () doesn't add */
+  memset(state_file, 0, sizeof(state_file));
+
   /* Get command line parameters */
   GET_PAR_S (1, "_Output bit stream file ...........................: ", data_file_name);
   FIND_PAR_C (2, "_Processing mode (Random,Frame,Burst) [RFB] .......: ", mode, mode);

--- a/src/utl/ugstdemo.h
+++ b/src/utl/ugstdemo.h
@@ -183,7 +183,7 @@
      fprintf (stderr,"%s%c\n",msg,C);}
 
 #define FIND_PAR_S(p,msg,i,dft) \
-   { memmove(i,(argc>p)?argv[p]:dft, strlen((argc>p)?argv[p]:dft));\
+   { memmove(i,(argc>p)?argv[p]:dft, strlen((argc>p)?argv[p]:dft)+1);\
      fprintf (stderr,"%s%s\n",msg,i); }
 
 #define FIND_PAR_L(p,msg,i,j) \


### PR DESCRIPTION
Fix for Issue #161 
Include terminating `\0` in `FIND_PAR_S()` string-copy operation using `strlen()` and `memmove()`. See discussion in #161 