### PR TITLE
is54/uvselp: fix segfault by adding ANSI C prototypes

### DIFF
--- a/src/is54/g_quant.c
+++ b/src/is54/g_quant.c
@@ -36,8 +36,7 @@ Motorola Inc.
 #include "vparams.h"
 /*#include "stdlib.h"*/
 /*	function declarations*/
-static FTYPE corr ();
-/*FTYPE *vec1Ptr, FTYPE *vec2Ptr*/
+static FTYPE corr (FTYPE *vec1Ptr, FTYPE *vec2Ptr);
 
 int G_QUANT (int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22) {
   FTYPE Rpc0;                   /* correlation between the weighted speech and the */

--- a/src/is54/interp.c
+++ b/src/is54/interp.c
@@ -32,8 +32,7 @@ Motorola Inc.
 #include <math.h>
 #include "vparams.h"
 
-int ATORC ();                   /* from paramConv.c */
-                /* FTYPE *a, FTYPE *k */
+int ATORC (FTYPE *a, FTYPE *k);                   /* from paramConv.c */
 void I_MOV (struct coefSet defSet, int numSets, FTYPE rq0);
 
 FTYPE RES_ENG (FTYPE rq0, FTYPE * k);
@@ -120,9 +119,7 @@ void I_MOV (struct coefSet defSet, int numSets, FTYPE rq0) {
 
 
 /*	RES_ENG calculates a residual energy estimate*/
-FTYPE RES_ENG (rq0, k)
-     FTYPE rq0;
-     FTYPE *k;
+FTYPE RES_ENG (FTYPE rq0, FTYPE *k)
 {
   FTYPE *endPtr /* , tmp = 1.0 */ , ftmp;
   double tmp = 1.0;

--- a/src/is54/lag.c
+++ b/src/is54/lag.c
@@ -36,8 +36,7 @@ Motorola Inc.
 #include "vparams.h"
 /*#include "stdlib.h"*/
 /*	function declarations*/
-static void i_resp ();
-/*FTYPE *htPtr*/
+static void i_resp (FTYPE *htPtr);
 
 
 int LAG_SEARCH () {

--- a/src/is54/makec.c
+++ b/src/is54/makec.c
@@ -37,8 +37,7 @@ Motorola Inc.
 #include "vparams.h"
 /*#include "stdlib.h"*/
 /*	from paramConv.c */
-int ATORC ();
-/*FTYPE *a, FTYPE *k*/
+int ATORC (FTYPE *a, FTYPE *k);
 
 void widen (FTYPE lambda, char side) {
   FTYPE term;                   /* holds lambda**i term (widening factor for Ai) */
@@ -66,15 +65,11 @@ void widen (FTYPE lambda, char side) {
 /*		 coefficients*/
 
 /*	function declarations */
-void ATOCOR ();
-/*FTYPE *k, FTYPE *ac*/
-void LEVINSON ();
-/*FTYPE *ac, FTYPE *a*/
+void ATOCOR (FTYPE *k, FTYPE *ac);
+void LEVINSON (FTYPE *ac, FTYPE *a);
 
 /*	function definition*/
-void A_SST (wCoefPtr, ssCoefPtr)
-     FTYPE *wCoefPtr;
-     FTYPE *ssCoefPtr;
+void A_SST (FTYPE *wCoefPtr, FTYPE *ssCoefPtr)
 {
   FTYPE *tmpKs;                 /* points to temporary reflection coef buffer */
   FTYPE *tmpAcs;                /* points to temp autocorrelation buffer */

--- a/src/is54/r_sub.h
+++ b/src/is54/r_sub.h
@@ -40,31 +40,24 @@ extern FTYPE RS00, RS11, RS22;
 /* Function declarations ...  */
 
 /*	from filters.c*/
-void I_DIR ();
-/*FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len*/
-void DIR ();
-/*FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len*/
+void I_DIR (FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len);
+void DIR (FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len);
 
 /*	from p_ex.c*/
-void P_EX ();
-/*FTYPE *oPtr, FTYPE *psPtr, int lag*/
+void P_EX (FTYPE *oPtr, FTYPE *psPtr, int lag);
 
 /*	from b_con.c*/
-void B_CON ();
-/*int codeWord, int numBits, FTYPE *bitArray*/
+void B_CON (int codeWord, int numBits, FTYPE *bitArray);
 
 /*	from v_con.c*/
-void V_CON ();
-/*FTYPE *basisPtr, FTYPE *bitArray, int numBasis, FTYPE *oPtr*/
+void V_CON (FTYPE *basisPtr, FTYPE *bitArray, int numBasis, FTYPE *oPtr);
 
 /*	from rs_rr.c*/
-FTYPE RS_RR ();
-/*FTYPE *vecPtr, FTYPE rs*/
+FTYPE RS_RR (FTYPE *vecPtr, FTYPE rs);
 
 /*	from excite.c*/
-FTYPE EXCITE ();
-/*int gsp0, int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22,
+FTYPE EXCITE (int gsp0, int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22,
 		FTYPE *pVecPtr, FTYPE *x1VecPtr, FTYPE *x2VecPtr,
-		FTYPE *oPtr*/
+		FTYPE *oPtr);
 
 /* ......................... End of file r_sub.h ........................... */

--- a/src/is54/t_sub.h
+++ b/src/is54/t_sub.h
@@ -38,53 +38,40 @@ extern FTYPE RS00, RS11, RS22;
 /*-------------------------------------------------------------------------*/
 /* Function declarations ...  */
 /* ... from filters.c*/
-void I_DIR ();
-/*FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len*/
-void DIR ();
-/*FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len*/
-void ZI_DIR ();
-/*FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len*/
+void I_DIR (FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len);
+void DIR (FTYPE *inPtr, FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len);
+void ZI_DIR (FTYPE *oPtr, FTYPE *stPtr, FTYPE *coefPtr, int len);
 
 /* ... from lag_search.c*/
-int LAG_SEARCH ();
-/*void*/
+int LAG_SEARCH (void);
 
 /* ... from p_ex.c*/
-void P_EX ();
-/*FTYPE *oPtr, FTYPE *psPtr, int lag*/
+void P_EX (FTYPE *oPtr, FTYPE *psPtr, int lag);
 
 /* ... from decorr.c*/
-void DECORR ();
-/*FTYPE *vecPtr, FTYPE *basisPtr, int numBasis*/
+void DECORR (FTYPE *vecPtr, FTYPE *basisPtr, int numBasis);
 
 /* ... from v_srch.c*/
-int V_SRCH ();
-/*FTYPE *wiPtr, FTYPE *wBasisPtr, int numBasis*/
+int V_SRCH (FTYPE *wiPtr, FTYPE *wBasisPtr, int numBasis);
 
 /* ... from b_con.c*/
-void B_CON ();
-/*int codeWord, int numBits, FTYPE *bitArray*/
+void B_CON (int codeWord, int numBits, FTYPE *bitArray);
 
 /* ... from v_con.c*/
-void V_CON ();
-/*FTYPE *basisPtr, FTYPE *bitArray, int numBasis, FTYPE *oPtr*/
+void V_CON (FTYPE *basisPtr, FTYPE *bitArray, int numBasis, FTYPE *oPtr);
 
 /* ... from rs_rr.c*/
-FTYPE RS_RR ();
-/*FTYPE *vecPtr, FTYPE rs*/
+FTYPE RS_RR (FTYPE *vecPtr, FTYPE rs);
 
 /* ... from g_quant.c*/
-int G_QUANT ();
-/*int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22*/
+int G_QUANT (int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22);
 
 /* ... from excite.c*/
-FTYPE EXCITE ();
-/*int gsp0, int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22,
+FTYPE EXCITE (int gsp0, int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22,
 		FTYPE *pVecPtr, FTYPE *x1VecPtr, FTYPE *x2VecPtr,
-		FTYPE *oPtr*/
+		FTYPE *oPtr);
 
 /* ... from weightedSnr.c*/
-void runningSnr ();
-/*FTYPE *speech, FTYPE *syn, FTYPE *wSpeech, FTYPE *wsyn*/
+void runningSnr (FTYPE *speech, FTYPE *syn, FTYPE *wSpeech, FTYPE *wsyn);
 
 /* ......................... End of file t_sub.h ........................... */

--- a/src/is54/vselp.c
+++ b/src/is54/vselp.c
@@ -187,7 +187,7 @@ int main (int argc, char *argv[]) {
   FTYPE *tmpPtr, *tmpPtr2, *endPtr, f1;
   int i, numRead;
   short *shPtr;
-  long (*get_codes) (), (*put_codes) ();
+  long (*get_codes) (FILE *, int *), (*put_codes) (FILE *, int *);
   long bs_read = 0, bs_saved = 0;
   char use_user_resp_file = 0;  /* Don't use user's response file */
   char InpFile[MAX_STRLEN], OutFile[MAX_STRLEN], LogFile[MAX_STRLEN], PackedFile[MAX_STRLEN];

--- a/src/is54/vselp.h
+++ b/src/is54/vselp.h
@@ -39,73 +39,55 @@ Motorola Inc.
 /*-------------------------------------------------------------------------*/
 /* Function declarations ...  */
 /* ... from getParams.c */
-void getParams ();
-/*FILE *fpget */
+void getParams (FILE *fpget);
 
 /* ... from calcParams.c */
-void calcParams ();
+void calcParams (void);
 
 /* ... from initTables.c */
-void initTables ();
+void initTables (void);
 
 /* ... from filt4.c */
-void FILT4 ();
-/*FTYPE *inPtr, int len */
+void FILT4 (FTYPE *inPtr, int len);
 
 /* ... from flatv.c */
-void FLATV ();
-FTYPE lookup ();
-/*int i */
+void FLATV (void);
+FTYPE lookup (int i);
 
 /* ... from paramConv.c */
-int ATORC ();
-/*FTYPE *a, FTYPE *k */
-int RCTOA ();
-/*FTYPE *k, FTYPE *a */
+int ATORC (FTYPE *a, FTYPE *k);
+int RCTOA (FTYPE *k, FTYPE *a);
 
 /* ... from interpolate.c */
-int INTERPOLATE ();
-/*struct coefSet defCoefs,
-		int numSets,
-		struct coefSet oCoefs,
-		int i,
-		FTYPE rq0 */
+int INTERPOLATE (struct coefSet defCoefs, int numSets,
+		struct coefSet oCoefs, int i, FTYPE rq0);
 
-void I_MOV ();
-/*struct coefSet defSet,
-	  int numSets,
-	  FTYPE	rq0 */
+void I_MOV (struct coefSet defSet, int numSets, FTYPE rq0);
 
-FTYPE RES_ENG ();
-/*FTYPE rq0, FTYPE *k */
+FTYPE RES_ENG (FTYPE rq0, FTYPE *k);
 
 /* ... from t_sub.c */
-void T_SUB ();
-/*int sfIndex */
+void T_SUB (int sfIndex);
 
 /* ... from putCodesEtc.c */
-long putCodesHex ();
-long putCodesBin ();
-/*int *paramP */
-long getCodesHex ();
-long getCodesBin ();
-/*int *codePtr */
-void putCodesLog ();
+long putCodesHex (FILE *fpstream, int *paramP);
+long putCodesBin (FILE *fpstream, int *paramP);
+long getCodesHex (FILE *fpcode, int *codePtr);
+long getCodesBin (FILE *fpcode, int *codePtr);
+void putCodesLog (void);
 
 /* ... from makeCoefs.c */
-void widen ();
-/*FTYPE lambda, char side */
-void A_SST ();
-/*FTYPE *wCoefPtr, FTYPE *ssCoefPtr */
+void widen (FTYPE lambda, char side);
+void A_SST (FTYPE *wCoefPtr, FTYPE *ssCoefPtr);
 
 /* ... from r_sub.c */
-void R_SUB ();
+void R_SUB (void);
 
 /* ... from weightedSnr.c */
-void printSnr ();
+void printSnr (FILE *fplog);
 
 /* ... from freeSpace.c */
-void freeSpace ();
+void freeSpace (void);
 
 /* external definitions */
 #include "edef.i"


### PR DESCRIPTION
# Fix uvselp segfault on modern compilers (GCC 6+, Clang, MSVC)

## Summary

Replace K&R-style empty-parentheses function declarations in `src/is54/` with proper ANSI C prototypes. This fixes segfaults/crashes that occur with any modern compiler.

Note that bit-exact output verification tests are not included because floating-point rounding produces platform-dependent results differing by more than ±1. This is pre-existing (#24) and inherent to float arithmetic, and original tests vectors could not be verified on any tested platforms (AMR64 and x86).

This PR:
* Fixes #41
* Fixes #132

## Problem

The IS-54 VSELP codec uses 1990-era K&R function declarations:

```c
/* In header files */
FTYPE EXCITE ();
FTYPE RS_RR ();
int G_QUANT ();

/* K&R function definition */
FTYPE RES_ENG (rq0, k)
     FTYPE rq0;
     FTYPE *k;
{ ... }
```

When `FTYPE` is `float` (the default), this triggers **C default argument promotion**: callers promote `float` arguments to `double` because no prototype is visible. But the function bodies expect `float` parameters. This ABI mismatch causes:

- **GCC 6+ / Clang on x86-64**: segfault in `EXCITE`. `gsp0` receives a garbage value because register assignments are shifted by the size mismatch
- **MSVC**: `assert(tmp >= 0)` fails in `RES_ENG` (interp.c:134). `rq0` receives corrupted data, producing negative values under `sqrt`
- **ARM64 (Apple Silicon, aarch64)**: bus error (EXC_BAD_ACCESS). `float` is passed in S registers, `double` in D registers, completely different register banks

## Fix

Added proper ANSI C prototypes to all header files and converted K&R function definitions to ANSI style:

| File | Change |
|------|--------|
| `r_sub.h` | Full prototypes for 7 functions |
| `t_sub.h` | Full prototypes for 12 functions |
| `vselp.h` | Full prototypes for 20 functions |
| `vselp.c` | Fix `get_codes`/`put_codes` function pointer declarations |
| `interp.c` | Convert `RES_ENG` K&R definition to ANSI; fix `ATORC` forward decl |
| `makec.c` | Convert `A_SST` K&R definition to ANSI; fix `ATORC`, `ATOCOR`, `LEVINSON` forward decls |
| `g_quant.c` | Fix `corr` forward declaration |
| `lag.c` | Fix `i_resp` forward declaration |

The internal precision remains `float` (FTYPE). The fix only corrects the calling convention so arguments are passed in the correct registers/stack positions. The algorithm and arithmetic are unchanged.