### PR TITLE
Fix compilation errors on modern C compilers and CMake >= 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10...3.31)
 project(STL2023 VERSION 2023)
 add_definitions( -DVERSION_STL="${CMAKE_PROJECT_NAME}" )
 

--- a/src/g711/shiftbit.c
+++ b/src/g711/shiftbit.c
@@ -97,7 +97,7 @@ int main (int argc, char *argv[]) {
 
   fprintf (stderr, "%s: Reading, ", inp);
   for (k = 0; k < l; k += 256)
-    if (fread (&buf[k],1, 512, fi) < 0)
+    if (fread (&buf[k],1, 512, Fi) < 0)
       KILL (inp, 5);
 
   fprintf (stderr, "shifting, ");

--- a/src/mnru/mnru.c
+++ b/src/mnru/mnru.c
@@ -723,7 +723,7 @@ double *P50_MNRU_process(char operation, MNRU_state *s, double* input, double* o
       return (NULL);
 
     /* Seed for random number generation (NO LONGER USED) */
-    s->seed = NULL;
+    s->seed = 0;
 
     /* Gain for signal path */
     if (mode == MOD_NOISE)

--- a/src/unsup/endian.c
+++ b/src/unsup/endian.c
@@ -9,7 +9,7 @@
   ---------------------------------------------------------------------------
 */
 
-reverse_endian_short (unsigned short *a, unsigned short *b, long n) {
+void reverse_endian_short (unsigned short *a, unsigned short *b, long n) {
   long i;
   unsigned short register tmp;
   for (i = 0; i < n; i++) {
@@ -26,7 +26,7 @@ reverse_endian_short (unsigned short *a, unsigned short *b, long n) {
   06.Oct.97  v1.0 Created <simao.campos@comsat.com>
   ---------------------------------------------------------------------------
 */
-reverse_endian_long (unsigned long *a, unsigned long *b, long n) {
+void reverse_endian_long (unsigned long *a, unsigned long *b, long n) {
   long i;
   union {
     unsigned long tmp;
@@ -52,7 +52,7 @@ int is_little_endian () {
 }
 
 void test_s () {
-  short a, b;
+  unsigned short a, b;
   while (1) {
     fread (&a, 1, sizeof (short), stdin);
     if (feof (stdin))
@@ -63,7 +63,7 @@ void test_s () {
 }
 
 void test_l () {
-  long a, b;
+  unsigned long a, b;
   while (1) {
     fread (&a, 1, sizeof (long), stdin);
     if (feof (stdin))

--- a/src/wmc_tool/CMakeLists.txt
+++ b/src/wmc_tool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10...3.31)
 project(wmc_tool)
 include(CTest)
 


### PR DESCRIPTION
This PR fixes compilation errors that prevent the STL from building with modern C compilers (Clang 17+, GCC 14+) and CMake >= 3.28.

## Changes

### CMake version policy (`CMakeLists.txt`, `src/wmc_tool/CMakeLists.txt`)

CMake 3.28+ removed compatibility with `cmake_minimum_required(VERSION)` values below 3.5. The previous `VERSION 3.1` caused a fatal configuration error:

```
Compatibility with CMake < 3.5 has been removed from CMake.
```

Updated to use the **range syntax** `VERSION 3.10...3.31`:
- The minimum (`3.10`) ensures broad compatibility with systems still running older CMake (e.g., Ubuntu 20.04 ships 3.16).
- The maximum (`3.31`) tells CMake which policy version the project has been tested against, preventing unexpected policy changes from newer CMake versions.
- This is the CMake-recommended approach for projects that need to support a range of CMake versions.

### `src/g711/shiftbit.c` - incompatible pointer to integer conversion

`fread()` was called with `fi` (an `int` file descriptor from `fileno()`) instead of `Fi` (the `FILE *` from `fopen()`). This was introduced when migrating from POSIX `read()` to `fread()` but the argument was not updated.

### `src/mnru/mnru.c` - incompatible integer to pointer conversion

`s->seed` is declared as `long` but was assigned `NULL` (a pointer type). Changed to `0`.

### `src/unsup/endian.c` - implicit int return type

`reverse_endian_short()` and `reverse_endian_long()` had no return type specifier, which defaults to `int` (invalid in C99 and later). Added explicit `void` return types. Also fixed signedness mismatch in `test_s()`/`test_l()` local variables.

## Testing

Successfully compiled and linked (100% targets) on:
- **macOS 26** (arm64) with Apple Clang 17, CMake 4.0.2
- **Ubuntu 24** (x86_64) with GCC/Clang, CMake 3.28.3

No functional changes (only type corrections and CMake version policy update).
