### PR TITLE
fix: initialize uninitialized variables detected by Memory Sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To build the STL tools, you need:
 
 Not so recent C compilers might also work (not tested).
 
+## Linux / macOS
+
 ```shell
 #Download source code
 git clone https://github.com/openitu/STL
@@ -26,15 +28,39 @@ git clone https://github.com/openitu/STL
 cd STL
 
 #Generate platform dependent build scripts using CMake
-#For using a specific generator see CMake parameter "-G"
 cmake .
 
-##Build STL tools
+#Build STL tools
 cmake --build .
 
-##Run tests (optional)
+#Run tests (optional)
 ctest
 ```
+
+## Windows
+
+Prerequisites:
+* Visual Studio with the **"Desktop development with C++"** workload installed
+* CMake (included with Visual Studio, or install separately)
+
+```powershell
+#Download source code
+git clone https://github.com/openitu/STL
+
+#Enter directory
+cd STL
+
+#Generate Visual Studio project files (adjust version as needed)
+cmake -G "Visual Studio 18 2026" .
+
+#Build STL tools
+cmake --build . --config Release
+
+#Run tests (optional)
+ctest -C Release
+```
+
+> **Note:** On Windows, you must specify a configuration (`Release` or `Debug`) for both the build and test steps.
 
 # Licenses
 The STL, and all of its derivations, is subject to the "ITU-T General Public License", which is a modified version of the GPL1.

--- a/src/eid/softbit.h
+++ b/src/eid/softbit.h
@@ -16,7 +16,7 @@
 
 /* ......... Smart prototypes .......... */
 #ifndef ARGS
-#if (defined(__STDC__) || defined(VMS) || defined(__DECC)  || defined(MSDOS) || defined(__MSDOS__))
+#if (defined(__STDC__) || defined(VMS) || defined(__DECC)  || defined(MSDOS) || defined(__MSDOS__) || defined(_MSC_VER))
 #define ARGS(x) x
 #else
 #define ARGS(x) ()

--- a/src/mnru/p50fbmnru.c
+++ b/src/mnru/p50fbmnru.c
@@ -14,8 +14,12 @@
 #define random_MNRU new_random_MNRU
 
 /* Defines minimum and maximum value for a short int. */
+#ifndef SHRT_MIN
 #define SHRT_MIN -32768
+#endif
+#ifndef SHRT_MAX
 #define SHRT_MAX +32767
+#endif
 
 void show_use(void)
 {


### PR DESCRIPTION
Fix uninitialized variable use detected by Clang Memory Sanitizer (MSan) and MSVC /analyze static analysis.

This fix also solves MS Visual C++ Runtime Library debug errors messages when running ctests in debug mode.

The top level readme is also updated to provide instructions for Windows users.

## Changes

| File | Fix |
|------|-----|
| `src/eid/bs-stats.c` | Initialize `out_file` to `"-"` (used uninitialized when `-q` flag disables logging) |
| `src/g728/g728fixed/g728fpdec.c` | Initialize `d->ogaindb` in decoder state (read by `g728fp_lgpred` before first write) |
| `src/is54/g_quant.c` | Initialize `Rpc0`, `Rcc00`, `Rcc01`, `Rcc02`, `savePtr` (conditionally assigned, used unconditionally) |
| `src/is54/init.c` | Replace all `malloc` with `calloc` for codec global arrays |
| `src/mnru/p50fbmnru.c` | Initialize `dcFilterMode` to 0 (uninitialized when `--overflow` is the only extra arg) |
| `src/mnru/snr.c` | Initialize `total_snr_dB` in SNR_RESET block |
| `src/wmc_tool/c_parser.cpp` | `memset` Insert record before filling; use `calloc` for table allocation |
| `src/wmc_tool/wmc_tool.cpp` | `memset` ParseContext to zero (uninitialized `InsertTbl.Data` pointer) |

## Verification

All fixes verified with Clang `-fsanitize=memory`. Only remaining MSan finding is `test_precision.c` which is a consequence of issue #189 (basop W_round portability bug), not an uninitialized variable.

No test output is affected — these are all cases where the uninitialized value is either overwritten before use in the output path, or the initialization to zero matches the intended default behavior.